### PR TITLE
feat(poller): play a sound cue when an agent stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Set with `tmux set-option -g <name> <value>` (or `set -g` in `~/.tmux.conf`):
 | `@agent-radar-processes` | `pi,claude,codex,opencode,hermes,aider,cursor` | Comma-separated agent executable names to detect; script/launcher-based agents (`hermes`, `opencode` via `uvx`, …) are matched by their command-line arguments too |
 | `@agent-radar-idle-seconds` | `3` | Seconds with no working indicator before a pane is "stopped" (the one calibration knob) |
 | `@agent-radar-poll-interval` | `2` | Seconds between poll cycles |
-| `@agent-radar-sound` | `on` | Play a short sound cue when an agent stops (in addition to the OS notification); `off` to mute. At most one sound per 3-second window across all panes. Requires `afplay` (macOS) or `canberra-gtk-play`/`paplay` (Linux); silent no-op if no player is found. |
+| `@agent-radar-sound` | `off` | Play a short sound cue when an agent stops (in addition to the OS notification); `on` to enable. At most one sound per 3-second window across all panes. Requires `afplay` (macOS) or `canberra-gtk-play`/`paplay` (Linux); silent no-op if no player is found. |
 | `@agent-radar-working-pattern` | braille + square-bar glyphs + `msg=interrupt` | ERE for an agent's live working indicator, matched byte-wise; defaults to the braille glyph (pi/claude/codex), opencode's square progress bar, or hermes' prompt-line running hint. Override for agents that use a different indicator |
 | `@agent-radar-key` | `a` | Prefix key that opens the navigator popup |
 | `@agent-radar-popup-width` | `40%` | Popup width |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Set with `tmux set-option -g <name> <value>` (or `set -g` in `~/.tmux.conf`):
 | `@agent-radar-processes` | `pi,claude,codex,opencode,hermes,aider,cursor` | Comma-separated agent executable names to detect; script/launcher-based agents (`hermes`, `opencode` via `uvx`, …) are matched by their command-line arguments too |
 | `@agent-radar-idle-seconds` | `3` | Seconds with no working indicator before a pane is "stopped" (the one calibration knob) |
 | `@agent-radar-poll-interval` | `2` | Seconds between poll cycles |
+| `@agent-radar-sound` | `on` | Play a short sound cue when an agent stops (in addition to the OS notification); `off` to mute. At most one sound per 3-second window across all panes. Requires `afplay` (macOS) or `canberra-gtk-play`/`paplay` (Linux); silent no-op if no player is found. |
 | `@agent-radar-working-pattern` | braille + square-bar glyphs + `msg=interrupt` | ERE for an agent's live working indicator, matched byte-wise; defaults to the braille glyph (pi/claude/codex), opencode's square progress bar, or hermes' prompt-line running hint. Override for agents that use a different indicator |
 | `@agent-radar-key` | `a` | Prefix key that opens the navigator popup |
 | `@agent-radar-popup-width` | `40%` | Popup width |

--- a/agent-radar.tmux
+++ b/agent-radar.tmux
@@ -13,7 +13,7 @@ opt() {
     [ -n "$v" ] && printf '%s' "$v" || printf '%s' "$2"
 }
 
-status_cmd="#($current_dir/scripts/agent-radar-status '#S')"
+status_cmd="#('$current_dir/scripts/agent-radar-status' '#S')"
 status_left=$(tmux show-option -gqv status-left 2>/dev/null || true)
 
 case "$status_left" in
@@ -53,4 +53,4 @@ case "$popup_position" in
 esac
 
 tmux bind-key "$popup_key" display-popup -E -e TERM=tmux-256color -w "$popup_width" -h "$popup_height" -x "$popup_x" -y "$popup_y" -d "#{pane_current_path}" "'$current_dir/scripts/agent-radar-list'"
-tmux run-shell -b "$current_dir/scripts/agent-radar-poller start"
+tmux run-shell -b "'$current_dir/scripts/agent-radar-poller' start"

--- a/agent-radar.tmux
+++ b/agent-radar.tmux
@@ -52,5 +52,5 @@ case "$popup_position" in
     *) popup_x=$popup_position; popup_y=$popup_position ;;
 esac
 
-tmux bind-key "$popup_key" display-popup -E -e TERM=tmux-256color -w "$popup_width" -h "$popup_height" -x "$popup_x" -y "$popup_y" -d "#{pane_current_path}" "$current_dir/scripts/agent-radar-list"
+tmux bind-key "$popup_key" display-popup -E -e TERM=tmux-256color -w "$popup_width" -h "$popup_height" -x "$popup_x" -y "$popup_y" -d "#{pane_current_path}" "'$current_dir/scripts/agent-radar-list'"
 tmux run-shell -b "$current_dir/scripts/agent-radar-poller start"

--- a/docs/adr/stop-sound-host-player.md
+++ b/docs/adr/stop-sound-host-player.md
@@ -1,0 +1,15 @@
+# Stop sound rides the notify flag through a host-player probe, not the tmux bell
+
+When a `working → stopped` transition sets the `notify` flag — the same flag that already fires the OS notification in `notify_stopped` in `agent-radar-poller` — the plugin also plays a short sound: `afplay` on a system sound on Darwin, else the first available Linux player, preferring a named event sound (`canberra-gtk-play -i complete`) so no audio asset ships with the plugin. Finding no player at all is a silent no-op, and a `@agent-radar-sound` user option (default on) gates the cue.
+
+## Why ride the notify flag
+
+The `notify` field emitted by `agent-radar-transition` already *is* the product decision: it is set only when `armed == "1"` — a pane observed `working` that then crossed its idle threshold. First-seen panes arm late and later stop as `unseen-stopped` with `notify = 0`, so they stay silent with zero new logic. Reusing the flag means there is no second definition of "worth hearing about" to drift from the one driving the OS notification.
+
+## Why not the tmux bell
+
+- The bell does have one genuine advantage: it propagates through tmux to the client terminal, so it stays audible over SSH where a host player is not. But tmux has no command to ring it — the only trigger is a pane emitting `\a` — so the plugin would have to spawn a throwaway window per cue and reap it, a race-prone hack for a sound the user's terminal config can silently eat anyway (`visual-bell`, per-terminal bell muting). `notify_stopped` already establishes the probe pattern: `osascript` on Darwin, else `notify-send` if present, else nothing. Sound following the same shape (`afplay`, else a player probe, else nothing) adds no new mechanism class, no new dependency, and no new failure semantics.
+
+## Cost
+
+Sound played on the tmux host is inaudible when driving tmux over SSH — accepted: the operator runs agents on the local machine, and "not at the machine" was explicitly out of scope for this feature. A flurry of stops can otherwise spam sound; a 3-second throttle (at most one sound per window) contains it. Shipping no asset means a stripped-down host with no player and no sound theme silently degrades the cue to the existing OS notification — the same degradation `notify-send`'s absence already causes today, which is why it costs nothing new.

--- a/docs/adr/stop-sound-host-player.md
+++ b/docs/adr/stop-sound-host-player.md
@@ -1,6 +1,6 @@
 # Stop sound rides the notify flag through a host-player probe, not the tmux bell
 
-When a `working → stopped` transition sets the `notify` flag — the same flag that already fires the OS notification in `notify_stopped` in `agent-radar-poller` — the plugin also plays a short sound: `afplay` on a system sound on Darwin, else the first available Linux player, preferring a named event sound (`canberra-gtk-play -i complete`) so no audio asset ships with the plugin. Finding no player at all is a silent no-op, and a `@agent-radar-sound` user option (default on) gates the cue.
+When a `working → stopped` transition sets the `notify` flag — the same flag that already fires the OS notification in `notify_stopped` in `agent-radar-poller` — the plugin also plays a short sound: `afplay` on a system sound on Darwin, else the first available Linux player, preferring a named event sound (`canberra-gtk-play -i complete`) so no audio asset ships with the plugin. Finding no player at all is a silent no-op, and a `@agent-radar-sound` user option (default off — zero surprise on upgrade, the maintainer's preference) gates the cue.
 
 ## Why ride the notify flag
 

--- a/scripts/agent-radar-poller
+++ b/scripts/agent-radar-poller
@@ -6,6 +6,7 @@ script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P) || exit 0
 store_cmd=$script_dir/agent-radar-store
 transition_cmd=$script_dir/agent-radar-transition
 match_cmd=$script_dir/agent-radar-match
+throttle_file="${AGENT_RADAR_SOUND_THROTTLE_FILE:-}"
 . "$script_dir/agent-radar-record-columns"
 eval "$(agent_radar_record_column_vars)"
 
@@ -105,11 +106,37 @@ on run argv
   display notification (item 2 of argv) with title ("agent-radar: " & item 1 of argv & " stopped")
 end run
 APPLESCRIPT
+    elif command -v notify-send >/dev/null 2>&1; then
+        notify-send "agent-radar: $1 stopped" "$2" >/dev/null 2>&1 &
+    fi
+
+    [ "$(opt @agent-radar-sound on)" = on ] || return 0
+
+    if [ -n "$throttle_file" ]; then
+        last_sound=$(stat -c %Y "$throttle_file" 2>/dev/null || stat -f %m "$throttle_file" 2>/dev/null || true)
+        if [ -n "$last_sound" ]; then
+            elapsed=$(($(date +%s) - last_sound))
+            if [ "$elapsed" -lt 3 ]; then
+                return 0
+            fi
+        fi
+        touch "$throttle_file" 2>/dev/null || true
+    fi
+
+    if [ "$(uname -s 2>/dev/null || true)" = Darwin ] && command -v afplay >/dev/null 2>&1; then
+        afplay /System/Library/Sounds/Ping.aiff >/dev/null 2>&1 &
         return 0
     fi
 
-    command -v notify-send >/dev/null 2>&1 || return 0
-    notify-send "agent-radar: $1 stopped" "$2" >/dev/null 2>&1 &
+    if command -v canberra-gtk-play >/dev/null 2>&1; then
+        canberra-gtk-play -i complete >/dev/null 2>&1 &
+        return 0
+    elif command -v paplay >/dev/null 2>&1; then
+        paplay /usr/share/sounds/freedesktop/stereo/complete.oga >/dev/null 2>&1 &
+        return 0
+    fi
+
+    return 0
 }
 
 valid_number() {
@@ -184,7 +211,10 @@ start() {
     fi
 
     pid_set "$$"
-    trap 'pid_unset "$$"; exit 0' INT TERM HUP EXIT
+    if [ -z "$throttle_file" ]; then
+        throttle_file=$(mktemp "${TMPDIR:-/tmp}/agent-radar-sound-throttle.XXXXXX") || exit 1
+    fi
+    trap 'rm -f "$throttle_file"; pid_unset "$$"; exit 0' INT TERM HUP EXIT
 
     # ponytail: list-sessions only needs the server, not an attached client;
     # display-message failed whenever every client briefly detached, ending

--- a/scripts/agent-radar-poller
+++ b/scripts/agent-radar-poller
@@ -110,7 +110,7 @@ APPLESCRIPT
         notify-send "agent-radar: $1 stopped" "$2" >/dev/null 2>&1 &
     fi
 
-    [ "$(opt @agent-radar-sound on)" = on ] || return 0
+    [ "$(opt @agent-radar-sound off)" = on ] || return 0
 
     if [ -n "$throttle_file" ]; then
         last_sound=$(stat -c %Y "$throttle_file" 2>/dev/null || stat -f %m "$throttle_file" 2>/dev/null || true)

--- a/scripts/agent-radar-status
+++ b/scripts/agent-radar-status
@@ -30,7 +30,7 @@ opt() {
 # every single render — only fork agent-radar-poller when it's actually dead.
 poller_pid=$(tmux show-option -gqv @agent-radar-pid 2>/dev/null || true)
 if [ -z "$poller_pid" ] || ! kill -0 "$poller_pid" 2>/dev/null; then
-    tmux run-shell -b "$poller_cmd start" >/dev/null 2>&1 || true
+    tmux run-shell -b "'$poller_cmd' start" >/dev/null 2>&1 || true
 fi
 
 "$store_cmd" records > "$records"

--- a/scripts/test-agent-radar-plugin
+++ b/scripts/test-agent-radar-plugin
@@ -37,5 +37,9 @@ grep -F 'set-option -g window-status-current-format #{?@agent-radar-window-stopp
     echo 'window-status-current-format does not include agent-radar stopped marker' >&2
     exit 1
 }
+grep -F "scripts/agent-radar-list'" "$log" >/dev/null || {
+    echo 'popup binding does not single-quote the list script path (breaks on plugin paths with spaces)' >&2
+    exit 1
+}
 
 printf 'agent-radar-plugin ok\n'

--- a/scripts/test-agent-radar-plugin
+++ b/scripts/test-agent-radar-plugin
@@ -41,5 +41,13 @@ grep -F "scripts/agent-radar-list'" "$log" >/dev/null || {
     echo 'popup binding does not single-quote the list script path (breaks on plugin paths with spaces)' >&2
     exit 1
 }
+grep -F "run-shell -b '" "$log" | grep -F "scripts/agent-radar-poller' start" >/dev/null || {
+    echo 'poller spawn does not single-quote the script path (run-shell goes through sh -c; breaks on plugin paths with spaces)' >&2
+    exit 1
+}
+grep -F "agent-radar-status' '#S'" "$log" >/dev/null || {
+    echo 'status-left command does not single-quote the status script path (breaks on plugin paths with spaces)' >&2
+    exit 1
+}
 
 printf 'agent-radar-plugin ok\n'

--- a/scripts/test-agent-radar-poller
+++ b/scripts/test-agent-radar-poller
@@ -297,6 +297,26 @@ afplay_log=$sound/afplay.log
 canberra_log=$sound/canberra.log
 paplay_log=$sound/paplay.log
 
+# Poll until $1 exists with at least $2 lines (~20ms interval, ~3s / 150 tries).
+# Optional $3 overrides the try cap (shorter absence settles). Returns 0, or 1 on timeout.
+wait_for() {
+    _wf_file=$1
+    _wf_min=$2
+    _wf_max=${3:-150}
+    _wf_n=0
+    while [ "$_wf_n" -lt "$_wf_max" ]; do
+        if [ -f "$_wf_file" ]; then
+            _wf_lines=$(wc -l < "$_wf_file")
+            if [ "$_wf_lines" -ge "$_wf_min" ]; then
+                return 0
+            fi
+        fi
+        _wf_n=$((_wf_n + 1))
+        sleep 0.02
+    done
+    return 1
+}
+
 # --- D1: sound off gate ---
 write_tmux_mock off
 cat > "$sound/bin/afplay" <<EOF
@@ -307,7 +327,7 @@ chmod +x "$sound/bin/afplay"
 
 PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture "$poller" once
 
-if [ -f "$afplay_log" ]; then
+if wait_for "$afplay_log" 1 50 || [ -f "$afplay_log" ]; then
     echo 'afplay was called while @agent-radar-sound is off' >&2
     exit 1
 fi
@@ -321,7 +341,7 @@ EOF
 chmod +x "$sound/bin/uname"
 PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture "$poller" once
 
-if [ -f "$afplay_log" ]; then
+if wait_for "$afplay_log" 1 50 || [ -f "$afplay_log" ]; then
     echo 'afplay was called while @agent-radar-sound is unset (must default to off)' >&2
     exit 1
 fi
@@ -344,9 +364,12 @@ chmod +x "$sound/bin/osascript"
 
 : > "$afplay_log"
 PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture "$poller" once
-sleep 0.2
-[ -s "$osascript_log" ] || {
+wait_for "$osascript_log" 1 || {
     echo 'Darwin OS notification was not emitted' >&2
+    exit 1
+}
+wait_for "$afplay_log" 1 || {
+    echo 'Darwin sound did not play Ping.aiff' >&2
     exit 1
 }
 grep -F '/System/Library/Sounds/Ping.aiff' "$afplay_log" >/dev/null || {
@@ -369,7 +392,10 @@ chmod +x "$sound/bin/canberra-gtk-play"
 rm -f "$sound/bin/afplay" "$canberra_log"
 
 PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture "$poller" once
-sleep 0.2
+wait_for "$canberra_log" 1 || {
+    echo 'canberra-gtk-play was not invoked with -i complete' >&2
+    exit 1
+}
 grep -F -- '-i complete' "$canberra_log" >/dev/null || {
     echo 'canberra-gtk-play was not invoked with -i complete' >&2
     exit 1
@@ -385,7 +411,10 @@ chmod +x "$sound/bin/paplay"
 rm -f "$sound/bin/canberra-gtk-play" "$paplay_log"
 
 PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture "$poller" once
-sleep 0.2
+wait_for "$paplay_log" 1 || {
+    echo 'paplay did not play fallback sound' >&2
+    exit 1
+}
 grep -F '/usr/share/sounds/freedesktop/stereo/complete.oga' "$paplay_log" >/dev/null || {
     echo 'paplay did not play fallback sound' >&2
     exit 1
@@ -417,7 +446,10 @@ throttle=$sound/throttle
 touch -t 200001010000 "$throttle"
 
 PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture AGENT_RADAR_SOUND_THROTTLE_FILE=$throttle "$poller" once
-sleep 0.2
+wait_for "$afplay_log" 1 || {
+    echo 'afplay not invoked on first (unthrottled) stop' >&2
+    exit 1
+}
 [ "$(wc -l < "$afplay_log")" -eq 1 ] || {
     echo 'afplay not invoked on first (unthrottled) stop' >&2
     exit 1
@@ -425,7 +457,10 @@ sleep 0.2
 
 sleep 1
 PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture AGENT_RADAR_SOUND_THROTTLE_FILE=$throttle "$poller" once
-sleep 0.2
+if wait_for "$afplay_log" 2 50; then
+    echo 'afplay invoked during throttle window' >&2
+    exit 1
+fi
 [ "$(wc -l < "$afplay_log")" -eq 1 ] || {
     echo 'afplay invoked during throttle window' >&2
     exit 1

--- a/scripts/test-agent-radar-poller
+++ b/scripts/test-agent-radar-poller
@@ -227,4 +227,194 @@ PATH=$alive/bin:$PATH AGENT_RADAR_STORE_FILE=$alive_store "$poller" start
 current=$(cat "$alive_pidfile")
 [ "$current" = "$$" ] || { echo 'start() overwrote a pid that was already alive (spawned a duplicate)' >&2; exit 1; }
 
+# --- Sound cue tests --------------------------------------------------------
+
+sound=$tmp/sound
+mkdir -p "$sound/bin"
+
+# Provide a private PATH so host binaries (e.g. /usr/bin/canberra-gtk-play)
+# do not leak into the sound-player probes.
+for _tool in awk cat cut date dirname grep mktemp rm sort stat touch tr sh; do
+    ln -s "$(command -v "$_tool")" "$sound/bin/$_tool"
+done
+rm -f "$sound/bin/tmux" "$sound/bin/ps" "$sound/bin/uname" "$sound/bin/notify-send"
+
+sound_fixture=$sound/fixture
+cat > "$sound_fixture" <<'EOF'
+TMUX_AGENT_RADAR_PANE_%1_AGENT=opencode
+TMUX_AGENT_RADAR_PANE_%1_TARGET=test:1.0
+TMUX_AGENT_RADAR_PANE_%1_LAST_CHANGE=100
+TMUX_AGENT_RADAR_PANE_%1_ARMED=1
+TMUX_AGENT_RADAR_PANE_%1_STATE=working
+TMUX_AGENT_RADAR_PANE_%1_STOPPED_AT=
+EOF
+
+cat > "$sound/bin/ps" <<'EOF'
+#!/usr/bin/env sh
+case "$1 $2 $3 $4 $5 $6" in
+    '-t ttys001 -o comm= -o args=') printf '%s\n' 'opencode /usr/local/bin/opencode' ;;
+    *) echo "unexpected ps $*" >&2; exit 1 ;;
+esac
+EOF
+chmod +x "$sound/bin/ps"
+
+cat > "$sound/bin/notify-send" <<'EOF'
+#!/usr/bin/env sh
+:
+EOF
+chmod +x "$sound/bin/notify-send"
+
+write_tmux_mock() {
+    _sound_value=$1
+    cat > "$sound/bin/tmux" <<EOF
+#!/usr/bin/env sh
+case "\$1" in
+    show-option)
+        case "\$3" in
+            @agent-radar-sound) printf '$_sound_value\n' ;;
+            @agent-radar-idle-seconds) printf '3\n' ;;
+            @agent-radar-poll-interval) printf '2\n' ;;
+            @agent-radar-processes) printf 'pi,claude,codex,opencode,hermes,aider,cursor\n' ;;
+            *) exit 0 ;;
+        esac
+        ;;
+    list-panes) printf '%%1|test:1.0|/dev/ttys001\n' ;;
+    capture-pane)
+        [ "\$1 \$2 \$3" = 'capture-pane -pJ -t' ] || { echo "unexpected capture-pane args: \$*" >&2; exit 1; }
+        case "\$4" in
+            %1) printf 'done\n' ;;
+            *) echo "unexpected capture-pane target: \$*" >&2; exit 1 ;;
+        esac
+        ;;
+    set-environment) : ;;
+    *) echo "unexpected tmux \$*" >&2; exit 1 ;;
+esac
+EOF
+    chmod +x "$sound/bin/tmux"
+}
+
+afplay_log=$sound/afplay.log
+canberra_log=$sound/canberra.log
+paplay_log=$sound/paplay.log
+
+# --- D1: sound off gate ---
+write_tmux_mock off
+cat > "$sound/bin/afplay" <<EOF
+#!/usr/bin/env sh
+printf 'afplay %s\n' "\$*" >> "$afplay_log"
+EOF
+chmod +x "$sound/bin/afplay"
+
+PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture "$poller" once
+
+if [ -f "$afplay_log" ]; then
+    echo 'afplay was called while @agent-radar-sound is off' >&2
+    exit 1
+fi
+
+# --- D2: Darwin sound on ---
+write_tmux_mock on
+cat > "$sound/bin/uname" <<'EOF'
+#!/usr/bin/env sh
+printf 'Darwin\n'
+EOF
+chmod +x "$sound/bin/uname"
+
+osascript_log=$sound/osascript.log
+: > "$osascript_log"
+cat > "$sound/bin/osascript" <<EOF
+#!/usr/bin/env sh
+printf 'osascript %s\n' "\$*" >> "$osascript_log"
+EOF
+chmod +x "$sound/bin/osascript"
+
+: > "$afplay_log"
+PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture "$poller" once
+sleep 0.2
+[ -s "$osascript_log" ] || {
+    echo 'Darwin OS notification was not emitted' >&2
+    exit 1
+}
+grep -F '/System/Library/Sounds/Ping.aiff' "$afplay_log" >/dev/null || {
+    echo 'Darwin sound did not play Ping.aiff' >&2
+    exit 1
+}
+
+# --- D3: Linux canberra-gtk-play ---
+write_tmux_mock on
+cat > "$sound/bin/uname" <<'EOF'
+#!/usr/bin/env sh
+printf 'Linux\n'
+EOF
+chmod +x "$sound/bin/uname"
+cat > "$sound/bin/canberra-gtk-play" <<EOF
+#!/usr/bin/env sh
+printf 'canberra-gtk-play %s\n' "\$*" >> "$canberra_log"
+EOF
+chmod +x "$sound/bin/canberra-gtk-play"
+rm -f "$sound/bin/afplay" "$canberra_log"
+
+PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture "$poller" once
+sleep 0.2
+grep -F -- '-i complete' "$canberra_log" >/dev/null || {
+    echo 'canberra-gtk-play was not invoked with -i complete' >&2
+    exit 1
+}
+
+# --- D4: Linux paplay fallback ---
+write_tmux_mock on
+cat > "$sound/bin/paplay" <<EOF
+#!/usr/bin/env sh
+printf 'paplay %s\n' "\$*" >> "$paplay_log"
+EOF
+chmod +x "$sound/bin/paplay"
+rm -f "$sound/bin/canberra-gtk-play" "$paplay_log"
+
+PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture "$poller" once
+sleep 0.2
+grep -F '/usr/share/sounds/freedesktop/stereo/complete.oga' "$paplay_log" >/dev/null || {
+    echo 'paplay did not play fallback sound' >&2
+    exit 1
+}
+
+# --- D5: no player on Linux ---
+write_tmux_mock on
+rm -f "$sound/bin/canberra-gtk-play" "$sound/bin/paplay" "$sound/bin/afplay"
+PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture "$poller" once
+
+# --- D6: throttle window ---
+# Run with an env-var-supplied throttle file and a Darwin-afplay shim so the
+# player path is deterministic: first call (old mtime) should fire; second call
+# (mtime touched within the 3-second window) should be throttled.
+write_tmux_mock on
+cat > "$sound/bin/uname" <<'EOF'
+#!/usr/bin/env sh
+printf 'Darwin\n'
+EOF
+chmod +x "$sound/bin/uname"
+cat > "$sound/bin/afplay" <<EOF
+#!/usr/bin/env sh
+printf 'afplay %s\n' "\$*" >> "$afplay_log"
+EOF
+chmod +x "$sound/bin/afplay"
+rm -f "$sound/bin/canberra-gtk-play" "$sound/bin/paplay" "$afplay_log"
+
+throttle=$sound/throttle
+touch -t 200001010000 "$throttle"
+
+PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture AGENT_RADAR_SOUND_THROTTLE_FILE=$throttle "$poller" once
+sleep 0.2
+[ "$(wc -l < "$afplay_log")" -eq 1 ] || {
+    echo 'afplay not invoked on first (unthrottled) stop' >&2
+    exit 1
+}
+
+sleep 1
+PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture AGENT_RADAR_SOUND_THROTTLE_FILE=$throttle "$poller" once
+sleep 0.2
+[ "$(wc -l < "$afplay_log")" -eq 1 ] || {
+    echo 'afplay invoked during throttle window' >&2
+    exit 1
+}
+
 printf 'agent-radar-poller ok\n'

--- a/scripts/test-agent-radar-poller
+++ b/scripts/test-agent-radar-poller
@@ -312,6 +312,20 @@ if [ -f "$afplay_log" ]; then
     exit 1
 fi
 
+# --- D1b: default off (option unset -> no sound) ---
+write_tmux_mock ''
+cat > "$sound/bin/uname" <<'EOF'
+#!/usr/bin/env sh
+printf 'Darwin\n'
+EOF
+chmod +x "$sound/bin/uname"
+PATH=$sound/bin AGENT_RADAR_STORE_FILE=$sound_fixture "$poller" once
+
+if [ -f "$afplay_log" ]; then
+    echo 'afplay was called while @agent-radar-sound is unset (must default to off)' >&2
+    exit 1
+fi
+
 # --- D2: Darwin sound on ---
 write_tmux_mock on
 cat > "$sound/bin/uname" <<'EOF'

--- a/scripts/test-agent-radar-status
+++ b/scripts/test-agent-radar-status
@@ -60,7 +60,7 @@ PATH=$tmp/bin:$PATH AGENT_RADAR_STORE_FILE=$fixture TMUX_LOG=$log "$status" work
 printf '#[fg=yellow][agents - work]#[default]' > "$tmp/expected-out"
 diff -u "$tmp/expected-out" "$tmp/out"
 
-grep -Fx "run-shell -b $script_dir/agent-radar-poller start" "$log" >/dev/null || {
+grep -Fx "run-shell -b '$script_dir/agent-radar-poller' start" "$log" >/dev/null || {
     echo 'poller heartbeat was not invoked' >&2
     exit 1
 }


### PR DESCRIPTION
## Summary

Add an audible stop cue: when a tracked agent pane transitions `working → stopped`, agent-radar can now play a short sound in addition to the existing OS notification. The cue is **off by default** (no surprise on upgrade) and is enabled with the new `@agent-radar-sound` tmux option.

## Motivation

Every existing stop cue is visual and attention-dependent — the OS notification can be muted or missed, and the status segment / window highlight must actively be looked at. When running several agents in parallel, a stopped pane can go unnoticed for a long time, stalling the rest of the pipeline. An ambient, attention-independent channel fixes exactly that failure mode.

## How it works

- The cue rides the existing `notify` flag emitted by `agent-radar-transition` (which already means "armed pane crossed idle, `working → stopped`"), so no transition logic changes and `unseen-stopped` stays silent.
- Playback probes the host in the same style as the existing OS-notification code: `afplay` on a macOS system sound (Darwin) → `canberra-gtk-play -i complete` → `paplay` → silent no-op when nothing is available. No audio asset ships and no new runtime dependency is introduced.
- A 3-second throttle caps playback at one sound per window across all panes; the OS notification itself stays per-stop and unchanged — the throttle gates the sound cue only.
- All playback is backgrounded with output redirected, so a missing or failing player can never break the poll loop under `set -eu`.

## Configuration

| Option | Default | Description |
| --- | --- | --- |
| `@agent-radar-sound` | `off` | Play a short sound cue when an agent stops (in addition to the OS notification); `on` to enable. At most one sound per 3-second window across all panes. Requires `afplay` (macOS) or `canberra-gtk-play`/`paplay` (Linux); silent no-op if no player is found. |

Documented in the README options table. The included ADR (`docs/adr/stop-sound-host-player.md`) records why a host-player probe was chosen over the tmux bell: tmux has no command to ring it cleanly, and terminal-side settings (`visual-bell`, per-terminal bell muting) can silently swallow it.

## Testing

- `test-agent-radar-poller` gains seven new cases: option off, option unset (defaults to off), Darwin notify + `afplay`, Linux `canberra-gtk-play`, `paplay` fallback, no-player no-op, and the throttle window — all using PATH-isolated fake players, so nothing leaks to the host.
- Full suite: 7/7 green. The new cases were verified to fail against the pre-feature poller (non-vacuous), and the pre-change tree was confirmed already green (no new failures introduced).
- While testing under a symlinked checkout whose path contains spaces, two latent quoting bugs surfaced and are fixed here: the navigator popup and every `run-shell`-spawned command (poller start, status heartbeat, `#()` status-left) now single-quote script paths so they survive tmux's `sh -c` round-trip. This also helps users whose plugin directory contains spaces (e.g. macOS home dirs).

## Notes for maintainers

- Purely additive: no exit-code/stdout contract, state-format, or existing-cue changes.
- POSIX sh throughout (`#!/usr/bin/env sh` + `set -eu`); no new runtime deps — still just tmux + POSIX sh (+ fzf for the navigator).
- Commits: `feat(poller)` for the implementation + tests + README row, `docs(adr)` for the decision record, `fix(navigator)`/`fix(entry)` for the space-path quoting fixes, and a final `feat(poller)` setting the default to off per review feedback.
